### PR TITLE
Infrastructure refactor

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -12,7 +12,14 @@ const cssLoader = {
     "sass-loader"
   ]
 };
+
+const mdLoader = {
+  test: /\.md$/,
+  loader: "raw"
+};
+
 module.exports = {
   babelLoader,
+  mdLoader,
   cssLoader
 };

--- a/config/webpack/webpack.common.js
+++ b/config/webpack/webpack.common.js
@@ -1,11 +1,19 @@
+const glob = require("glob");
 const path = require("path");
 
-const { babelLoader, cssLoader } = require("./loaders");
+const { babelLoader, cssLoader, mdLoader } = require("./loaders");
 
 module.exports = {
-  entry: {
-    index: "./src/index.js"
-  },
+  entry: glob.sync("./src/components/**/*.js").reduce(
+    (entries, entry) =>
+      Object.assign(entries, {
+        [entry
+          .split("/")
+          .pop()
+          .replace(".js", "")]: entry
+      }),
+    { index: path.join(__dirname, "../../src/index.js") }
+  ),
   externals: {
     react: "react"
   },
@@ -13,9 +21,9 @@ module.exports = {
     filename: "[name].js",
     path: path.resolve(process.cwd(), "dist"),
     library: "@kenshooui/react-menu",
-    libraryTarget: "commonjs2"
+    libraryTarget: "umd"
   },
   module: {
-    rules: [babelLoader, cssLoader]
+    rules: [babelLoader, cssLoader, mdLoader]
   }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server --config config/webpack/webpack.dev.js --mode development",
     "build": "webpack --config config/webpack/webpack.dev.js --mode development",
     "build:stats": "NODE_ENV=production webpack  --config config/webpack/webpack.prod.js -p --bail --json > stats.json  --mode production",
     "build:production": "webpack --config config/webpack/webpack.prod.js --mode production",
@@ -49,6 +48,7 @@
     "eslint-config-prettier": "^3.0.1",
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-react": "^7.11.1",
+    "glob": "^7.1.3",
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4505,7 +4505,7 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1, glob@~7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:


### PR DESCRIPTION
A script was added to the entry parameter in order to support two kinds of imports:
```js
import { Component } from "@kenshooui/react-menu"
```
and
```js
import Component from "@kenshooui/react-menu/component"
```

We provide a script to the `entry` property in webpack.config that iterates over our components directory and maps each component's path to an a string in the entries object. 
The files are transpiled to "umd" modules, removing the option for tree shaking.
For instance, if a component imports a component from a library, this library will be included as a whole, even if the user has tree shaking enabled on his environment. This PR includes this change.
_____
I propose a different solution to this requirement.
After looking into this on other component libraries like **material-ui**, **blueprint** and **react-bootstrap** I found a different approach.

Let's begin with some package.jsons:

**react-bootstrap**
![screenshot from 2018-08-28 13-27-26](https://user-images.githubusercontent.com/16524839/44717621-2e30d980-aac6-11e8-8f6f-91066be8545f.png)
![screenshot from 2018-08-28 13-27-42](https://user-images.githubusercontent.com/16524839/44717625-2f620680-aac6-11e8-8dbc-d112f8b6b95d.png)

**material-ui**
![screenshot from 2018-08-28 13-29-09](https://user-images.githubusercontent.com/16524839/44717678-5ddfe180-aac6-11e8-9465-b39fb7f85bf6.png)

**blueprint**
![screenshot from 2018-08-28 13-29-42](https://user-images.githubusercontent.com/16524839/44717726-7fd96400-aac6-11e8-8476-044410dfcdf0.png)

We can see that there is a separation between the main file and the module file.
The main file of the package is a umd / commonJS version of the package. This file will be read by consumers / bundlers / tools that doesn't support es modules.
The module file will be read by tools and bundlers that support esm.
When we publish esm modules we even support new browsers.

> module is now standardized and is used by bundlers as a lookup for the ESM version of the library/package.
 
If we look into the components of the libraries above, we see that the components were not bundled but transpiled via babel or typescript:

menu.js of **blueprint**:
![screenshot from 2018-08-28 13-37-18](https://user-images.githubusercontent.com/16524839/44718053-874d3d00-aac7-11e8-9a81-8e9549a2e8a4.png)

index.js of **blueprint**:
![screenshot from 2018-08-28 13-37-48](https://user-images.githubusercontent.com/16524839/44718081-916f3b80-aac7-11e8-927d-2525289a03fc.png)

We can see this pattern in **react-bootstrap** as well:
index file in "es" folder:
![screenshot from 2018-08-28 13-47-05](https://user-images.githubusercontent.com/16524839/44718494-e9f30880-aac8-11e8-87e6-93d6f71ac38c.png)

index file in lib folder (umd):
![screenshot from 2018-08-28 13-47-44](https://user-images.githubusercontent.com/16524839/44718508-f5deca80-aac8-11e8-8857-86a5fdc30802.png)

`blueprint` was transpiled with typescript and `react-bootstrap` with babel. 

> For the UI Library, we need to transpile the source with Babel with the es module system as a target, and place it in lib. We can even host the lib on a CDN.

Check out this difference as well:
![image](https://user-images.githubusercontent.com/16524839/44719135-0d1eb780-aacb-11e8-8b27-3a242998c5c9.png)
taken from here: https://medium.freecodecamp.org/anatomy-of-js-module-systems-and-building-libraries-fadcd8dbd0e

This will not require entrypoints. We just need babel to transpile our code for two module systems and include our CSS in our JS. 

Also notice that the "sideEffects" was set to false to enable webpack 4's tree shaking.
Rollup has tree shaking configured by default as well as Parcel.
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

I think that we should implement this approach across our repos and maybe even get rid of webpack for our react component libraries.

@liorheber @AmirAsaraf @johanzilber 


