### PR TITLE
Fix RightMenuContainer in case there is flex on parent

### DIFF
--- a/src/components/right_menu_container/right_menu_container.scss
+++ b/src/components/right_menu_container/right_menu_container.scss
@@ -1,4 +1,5 @@
 .right_menu_container {
-  float: right;
   height: 100%;
+  float: right;
+  margin-left: auto;
 }


### PR DESCRIPTION
Added `margin-left: auto;` in right_menu_container.scss to ensure that it will appear on the right.
This works with and without `display: flex` on parent.

@AmirAsaraf @liorheber @johanzilber 