### PR TITLE
Menu activeElement / onSelect functionality - context api example

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -2,9 +2,11 @@ import React from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
+import WithMenuContext from "../with_menu_context";
+
 import styles from "./button.scss";
 
-export const Button = ({
+const Button = ({
   className,
   disabledClassName,
   children,
@@ -39,3 +41,5 @@ Button.defaultProps = {
   isDisabled: false,
   children: []
 };
+
+export default WithMenuContext(Button);

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2,11 +2,13 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import styles from "./dropdown.scss";
 import { Button } from "../../";
 import { DOWN, RIGHT } from "./items_direction_consts";
+import WithMenuContext from "../with_menu_context";
 
-export default class Dropdown extends Component {
+import styles from "./dropdown.scss";
+
+class Dropdown extends Component {
   static propTypes = {
     className: PropTypes.string,
     disabledClassName: PropTypes.string,
@@ -30,19 +32,11 @@ export default class Dropdown extends Component {
     ])
   };
 
-  state = {
-    isOpened: false
-  };
-
-  open = event => {
+  open = () => {
     if (this.props.isDisabled) {
       return;
     }
-    this.setState({ isOpened: true });
-  };
-
-  close = event => {
-    this.setState({ isOpened: false });
+    this.props.setActiveElement(this.props.label);
   };
 
   onClick = event => {
@@ -63,8 +57,6 @@ export default class Dropdown extends Component {
       children
     } = this.props;
 
-    const { isOpened } = this.state;
-
     return (
       <div>
         <Button
@@ -74,11 +66,11 @@ export default class Dropdown extends Component {
             className
           )}
           disabled={isDisabled}
-          onClick={isOpened ? this.close : this.open}
+          onClick={this.open}
         >
           {label}
         </Button>
-        {isOpened && (
+        {this.props.label === this.props.activeElement && (
           <div
             className={classnames(
               { [styles.dropdown_items_down]: itemsDirection === DOWN },
@@ -94,3 +86,5 @@ export default class Dropdown extends Component {
     );
   }
 }
+
+export default WithMenuContext(Dropdown);

--- a/src/components/left_menu_container/left_menu_container.js
+++ b/src/components/left_menu_container/left_menu_container.js
@@ -2,9 +2,11 @@ import React from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
+import WithMenuContext from "../with_menu_context";
+
 import styles from "./left_menu_container.scss";
 
-export const LeftMenuContainer = ({ className, children }) => (
+const LeftMenuContainer = ({ className, children }) => (
   <div className={classnames(styles.left_menu_container, className)}>
     {children}
   </div>
@@ -14,3 +16,5 @@ LeftMenuContainer.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node
 };
+
+export default WithMenuContext(LeftMenuContainer);

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -1,8 +1,31 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import classnames from "classnames";
 
 import styles from "./menu.scss";
 
-export const Menu = ({ className, children }) => (
-  <div className={classnames(styles.menu, className)}>{children}</div>
-);
+export const MenuContext = React.createContext({});
+
+class Menu extends PureComponent {
+  state = {
+    activeElement: undefined
+  };
+
+  setActiveElement = activeElement => this.setState({ activeElement });
+
+  render() {
+    return (
+      <MenuContext.Provider
+        value={{
+          ...this.state,
+          setActiveElement: this.setActiveElement
+        }}
+      >
+        <div className={classnames(styles.menu, this.props.className)}>
+          {this.props.children}
+        </div>
+      </MenuContext.Provider>
+    );
+  }
+}
+
+export default Menu;

--- a/src/components/right_menu_container/right_menu_container.js
+++ b/src/components/right_menu_container/right_menu_container.js
@@ -2,9 +2,11 @@ import React from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
+import WithMenuContext from "../with_menu_context";
+
 import styles from "./right_menu_container.scss";
 
-export const RightMenuContainer = ({ className, children }) => (
+const RightMenuContainer = ({ className, children }) => (
   <div className={classnames(styles.right_menu_container, className)}>
     {children}
   </div>
@@ -14,3 +16,5 @@ RightMenuContainer.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node
 };
+
+export default WithMenuContext(RightMenuContainer);

--- a/src/components/with_menu_context.js
+++ b/src/components/with_menu_context.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+import { MenuContext } from "./menu";
+
+const WithMenuContext = WrappedComponent => props => (
+  <MenuContext.Consumer>
+    {context => <WrappedComponent {...context} {...props} />}
+  </MenuContext.Consumer>
+);
+
+export default WithMenuContext;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-export { Menu } from "./components/menu";
-export { Button } from "./components/button/button";
-export { Dropdown } from "./components/dropdown/dropdown";
+export { default as Menu } from "./components/menu";
+export { default as Button } from "./components/button/button";
+export { default as Dropdown } from "./components/dropdown/dropdown";
 export {
-  RightMenuContainer
+  default as RightMenuContainer
 } from "./components/right_menu_container/right_menu_container";
 export {
-  LeftMenuContainer
+  default as LeftMenuContainer
 } from "./components/left_menu_container/left_menu_container";

--- a/stories/menu.stories.js
+++ b/stories/menu.stories.js
@@ -73,6 +73,24 @@ storiesOf("Dropdown", module)
         <SampleDropDownMenuItem>item 1</SampleDropDownMenuItem>
         <SampleDropDownMenuItem>item 2</SampleDropDownMenuItem>
         <SampleDropDownMenuItem>item 3</SampleDropDownMenuItem>
+      </Dropdown>{" "}
+      <Dropdown
+        label={"Dimple"}
+        onClick={action("item clicked")}
+        isDisabled={boolean("disabled", false)}
+        className={text("custom className", `${styles.custom_dropdown}`)}
+        disabledClassName={text(
+          "custom disabledClassName",
+          `${styles.custom_dropdown_disabled}`
+        )}
+        itemsClassName={text(
+          "custom itemsClassName",
+          `${styles.custom_dropdown_items}`
+        )}
+      >
+        <SampleDropDownMenuItem>item 1</SampleDropDownMenuItem>
+        <SampleDropDownMenuItem>item 2</SampleDropDownMenuItem>
+        <SampleDropDownMenuItem>item 3</SampleDropDownMenuItem>
       </Dropdown>
     </Menu>
   ))


### PR DESCRIPTION
Active element via context API - example.

We let the user to decide the element's selector and we save it as active element in our context.
For example, the selector will be the label of our components.

We provide two things in its state: 
- `activeElement`: currently selected element, defined by the user
- `setActiveElement`: method that gets a value (any value) and sets it to context's state

Check it out in storybook.

@liorheber @johanzilber @AmirAsaraf WDYT?