### PR TITLE
Button component refactor

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -11,7 +11,7 @@ setOptions({
   showLeftPanel: true,
   showDownPanel: true,
   showSearchBox: false,
-  downPanelInRight: false,
+  downPanelInRight: true,
   sortStoriesByKind: false
 });
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -1,47 +1,48 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
+import WithMenuContext from "../with_menu_context";
+
 import styles from "./button.scss";
 
-const Button = ({
-  className,
-  disabledClassName,
-  children,
-  isDisabled,
-  onClick,
-  ...props
-}) => {
-  return (
-    <div
-      className={classnames(
-        styles.button,
-        { [disabledClassName || styles.disabled]: isDisabled },
-        className
-      )}
-      disabled={isDisabled}
-      onClick={event => {
-        !isDisabled ? onClick(event) : {};
-      }}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-};
+class Button extends PureComponent {
+  static propTypes = {
+    className: PropTypes.string,
+    disabledClassName: PropTypes.string,
+    isDisabled: PropTypes.bool,
+    children: PropTypes.node
+  };
 
-Button.propTypes = {
-  className: PropTypes.string,
-  disabledClassName: PropTypes.string,
-  isDisabled: PropTypes.bool,
-  children: PropTypes.node
-};
+  static defaultProps = {
+    className: "",
+    disabledClassName: "",
+    isDisabled: false,
+    children: []
+  };
 
-Button.defaultProps = {
-  className: "",
-  disabledClassName: "",
-  isDisabled: false,
-  children: []
-};
+  onClick = () => {
+    this.props.onSelectElement(this.props.children);
+    this.props.onClick();
+  };
 
-export default Button;
+  render() {
+    const { className, disabledClassName, children, isDisabled } = this.props;
+
+    return (
+      <button
+        className={classnames(
+          styles.button,
+          { [disabledClassName || styles.disabled]: isDisabled },
+          className
+        )}
+        disabled={isDisabled}
+        onClick={this.onClick}
+      >
+        {children}
+      </button>
+    );
+  }
+}
+
+export default WithMenuContext(Button);

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -2,7 +2,11 @@
 
 .button {
   padding: 1em;
+  font-size: 1em;
   cursor: pointer;
+  background: none;
+  border: none;
+  outline: none;
 }
 
 .disabled {

--- a/stories/button.stories/button.stories.js
+++ b/stories/button.stories/button.stories.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import { boolean, text, withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+
+import { Button, Menu } from "../../src";
+
+import styles from "./button.stories.scss";
+
+storiesOf("Button", module)
+  .addDecorator(withKnobs)
+  .add("Button", () => (
+    <Menu>
+      <Button onClick={action("Button clicked")}>Button</Button>
+      <Button
+        onClick={action("Button clicked")}
+        isDisabled={boolean("disabled", true)}
+      >
+        Disabled Button
+      </Button>
+      <Button
+        className={text("custom className", styles.custom_button)}
+        onClick={action("Button clicked")}
+      >
+        Custom Button
+      </Button>
+      <Button
+        disabledClassName={text(
+          "custom disabled className",
+          styles.disabled_custom_button
+        )}
+        onClick={action("Button clicked")}
+        isDisabled
+      >
+        Disabled Custom Button
+      </Button>
+    </Menu>
+  ));

--- a/stories/button.stories/button.stories.scss
+++ b/stories/button.stories/button.stories.scss
@@ -1,0 +1,9 @@
+.custom_button {
+  background: #0caee2;
+  color: white;
+}
+
+.disabled_custom_button {
+  background: #777777;
+  color: white;
+}

--- a/stories/menu.stories.js
+++ b/stories/menu.stories.js
@@ -17,9 +17,10 @@ import { SampleItem } from "./sample_item";
 import { SampleItemWithSeperator } from "./sample_item_seperator";
 
 storiesOf("Menu", module)
+  .addDecorator(withKnobs)
   .add("Default view", () => (
     <Menu>
-      <Button isDisabled={true}>Button</Button>
+      <Button onClick={action("Button clicked")}>Button</Button>
       <Dropdown label={"Dropdown"}>
         <div>item 1</div>
         <div>item 2</div>
@@ -160,15 +161,5 @@ storiesOf("Dropdown", module)
           <div>sub item 2</div>
         </Dropdown>
       </Dropdown>
-    </Menu>
-  ));
-
-storiesOf("Button", module)
-  .addDecorator(withKnobs)
-  .add("Simple", () => (
-    <Menu className={styles.menu}>
-      <Button onClick={action("Button clicked")} isDisabled={true}>
-        Button
-      </Button>
     </Menu>
   ));

--- a/tests/components/button/__snapshots__/button.spec.js.snap
+++ b/tests/components/button/__snapshots__/button.spec.js.snap
@@ -2,40 +2,52 @@
 
 exports[`Button component disabled Button 1`] = `
 <div
-  className="button disabled"
-  disabled={true}
-  onClick={[Function]}
+  className="menu"
 >
-  TEST
+  <button
+    className="button disabled"
+    disabled={true}
+    onClick={[Function]}
+  >
+    TEST
+  </button>
 </div>
 `;
 
 exports[`Button component disabledClassName prop 1`] = `
-<div
+<button
   className="button DISABLED_CLASS"
   disabled={true}
   onClick={[Function]}
 >
   TEST
-</div>
+</button>
 `;
 
 exports[`Button component recieves className 1`] = `
 <div
-  className="button TEST_CLASS"
-  disabled={false}
-  onClick={[Function]}
+  className="menu"
 >
-  TEST
+  <button
+    className="button TEST_CLASS"
+    disabled={false}
+    onClick={[Function]}
+  >
+    TEST
+  </button>
 </div>
 `;
 
 exports[`Button component renders children 1`] = `
 <div
-  className="button"
-  disabled={false}
-  onClick={[Function]}
+  className="menu"
 >
-  TEST
+  <button
+    className="button"
+    disabled={false}
+    onClick={[Function]}
+  >
+    TEST
+  </button>
 </div>
 `;

--- a/tests/components/button/button.spec.js
+++ b/tests/components/button/button.spec.js
@@ -2,21 +2,33 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 
-import { Button } from "../../../src/";
+import { Menu, Button } from "../../../src/";
 
 describe("Button component", () => {
   test("renders children", () => {
-    const cmp = renderer.create(<Button>TEST</Button>);
+    const cmp = renderer.create(
+      <Menu>
+        <Button>TEST</Button>
+      </Menu>
+    );
     expect(cmp).toMatchSnapshot();
   });
 
   test("recieves className", () => {
-    const cmp = renderer.create(<Button className="TEST_CLASS">TEST</Button>);
+    const cmp = renderer.create(
+      <Menu>
+        <Button className="TEST_CLASS">TEST</Button>
+      </Menu>
+    );
     expect(cmp).toMatchSnapshot();
   });
 
   test("disabled Button", () => {
-    const cmp = renderer.create(<Button isDisabled>TEST</Button>);
+    const cmp = renderer.create(
+      <Menu>
+        <Button isDisabled>TEST</Button>
+      </Menu>
+    );
     expect(cmp).toMatchSnapshot();
   });
 
@@ -31,18 +43,24 @@ describe("Button component", () => {
 
   test("triggers onClick", () => {
     const mockFn = jest.fn();
-    const cmp = mount(<Button onClick={mockFn}>TEST</Button>);
+    const cmp = mount(
+      <Menu>
+        <Button onClick={mockFn}>TEST</Button>
+      </Menu>
+    );
 
-    cmp.simulate("click");
+    cmp.find(Button).simulate("click");
     expect(mockFn).toHaveBeenCalled();
   });
 
   test("cannot click on disabled button", () => {
     const mockFn = jest.fn();
     const cmp = mount(
-      <Button isDisabled={true} onClick={mockFn}>
-        TEST
-      </Button>
+      <Menu>
+        <Button isDisabled onClick={mockFn}>
+          TEST
+        </Button>
+      </Menu>
     );
 
     cmp.simulate("click");


### PR DESCRIPTION
Button component refactored to use onSelectElement.
Updated storybook and a small change in styles.

MAKE SURE TO MERGE AND REBASE AFTER  https://github.com/kenshoo/react-menu/pull/31

NOTE
notice that `onSelectElement` receives button's children. This is sub optimal because children can be objects as well, and for that we'll / the user will need deep comparison. We can decide to use a const that will act as the` selectElement`'s id... WDYT?

@liorheber @johanzilber @AmirAsaraf @hadasgazit 