### PR TITLE
fix(dropdown): Padding to margin

### DIFF
--- a/src/components/dropdown/dropdown_icon/dropdown_icon.scss
+++ b/src/components/dropdown/dropdown_icon/dropdown_icon.scss
@@ -2,7 +2,7 @@
 
 .icon {
   font-size: 8px;
-  padding: 0 0 0 8px;
+  margin: 0 0 0 8px;
 }
 
 .disabled {


### PR DESCRIPTION
Fixes https://github.com/kenshoo/react-menu/issues/51

Problem: 
When using "box-sizing: border-box", arrows are not shown for dropdowns because of usage both padding styles and fixed width for svg

## Proposed Changes
Change padding to margin usage